### PR TITLE
fix: resolves commit hook formatted files #3

### DIFF
--- a/.cljstyle
+++ b/.cljstyle
@@ -1,0 +1,3 @@
+;; cljstyle configuration
+{:files {:ignore #{"target" "docs"}}
+ :rules {:blank-lines {:max-consecutive 3}}}

--- a/bb.edn
+++ b/bb.edn
@@ -22,4 +22,7 @@
 	 hooks  	{:doc           "Git hook related commands."
                  	 :requires      ([git-hooks :as gh])
                  	 :task          (apply gh/hooks *command-line-args*)}
+         foo            {:doc      ""
+                         :requires  	([tasks :as t])
+                         :task     t/foo}
 }}

--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -3,8 +3,11 @@
   This includes perform tests and building the library."
   (:require
     [babashka.process :refer [shell sh]]
+    [clci.git-hooks-utils :refer [changed-files]]
     [clojure.edn :as edn]
-    [clojure.term.colors :as c]))
+    [clojure.string :as str]
+    [clojure.term.colors :as c]
+    [format :as fmt]))
 
 
 (defn run-tests
@@ -21,3 +24,7 @@
   (-> (sh "clj -M:nREPL -m nrepl.cmdline") :out println))
 
 
+(defn foo
+  ""
+
+  [])

--- a/deps.edn
+++ b/deps.edn
@@ -1,22 +1,27 @@
 {:paths ["src/clj"]
+ :description "ClCI"
+ :url       "https://github.com/ClockworksIO/clci"
+ :scm       {:name "git"
+             :url "git@github.com:ClockworksIO/clci.git"}
+ :license   {:name "Apache-2.0"
+             :url "https://www.apache.org/licenses/LICENSE-2.0"}
  :deps
-  {org.clojure/clojure                      {:mvn/version   "1.11.1"}
-   instaparse/instaparse 					{:mvn/version "1.4.12"}
-   org.endot/bb-pod-racer 					{:mvn/version "0.1.9"}}
+ {org.clojure/clojure                 {:mvn/version   "1.11.1"}
+  instaparse/instaparse 					{:mvn/version "1.4.12"}
+  org.endot/bb-pod-racer 					{:mvn/version "0.1.9"}}
 
  :aliases
-  {:test                {:extra-paths       ["test"]
-                         :main-opts         ["-m" "kaocha.runner"]
-                         :extra-deps        {lambdaisland/kaocha    {:mvn/version "1.70.1086"}}}
-   :nREPL			    {:extra-deps 		{nrepl/nrepl 			{:mvn/version "1.0.0"}}}
-   :format				{:deps 				{mvxcvi/cljstyle 		{:mvn/version "0.15.0"}}}
-   :build               {:deps    			{io.github.clojure/tools.build 	        {:git/tag "v0.8.5" :git/sha "9c738da"}
-                                             com.github.clj-easy/graal-build-time   {:mvn/version "0.1.4"}}
-						 :ns-default        build}
+ {:test                {:extra-paths     ["test"]
+                        :main-opts       ["-m" "kaocha.runner"]
+                        :extra-deps      {lambdaisland/kaocha                    {:mvn/version "1.70.1086"}}}
+  :nREPL			      {:extra-deps 		{nrepl/nrepl 			                   {:mvn/version "1.0.0"}}}
+  :format				   {:deps 				{mvxcvi/cljstyle 		                   {:mvn/version "0.15.0"}}}
+  :build               {:deps    			{io.github.clojure/tools.build 	       {:git/tag "v0.8.5" :git/sha "9c738da"}
+                                     com.github.clj-easy/graal-build-time   {:mvn/version "0.1.4"}}
+                        :ns-default       build}
   }
 
- :build
-  {:version         "0.0.0"					; uses semantic versioning!
-   :target-dir	    "target" 				; target directory for build artifacts
-   :lib-name        'clockworks/clci}
-}
+ :build                 {:version         "0.0.0"					; uses semantic versioning!
+                         :target-dir	   "target" 				; target directory for build artifacts
+                         :lib-name        'clockworks/clci}
+ }

--- a/src/bb/clci/git_hooks_utils.clj
+++ b/src/bb/clci/git_hooks_utils.clj
@@ -3,7 +3,7 @@
   **Note**: This code is based on https://blaster.ai/blog/posts/manage-git-hooks-w-babashka.html"
   (:require
     [babashka.fs :as fs]
-    [babashka.process :refer [sh]]
+    [babashka.process :refer [sh shell]]
     [clojure.string :as str]))
 
 
@@ -29,11 +29,9 @@ bb hooks %s" (java.util.Date.) hook))
 (defn changed-files
   "Get a collection of all changed files."
   []
-  (->> (sh "git" "diff" "--name-only" "--cached" "--diff-filter=ACM")
-       :out
-       str/split-lines
-       (filter seq)
-       seq))
+  (-> (shell {:out :string} "git --no-pager diff --name-only --no-color --cached --diff-filter=ACM")
+      :out
+      str/split-lines))
 
 
 (def extensions

--- a/src/clj/user.clj
+++ b/src/clj/user.clj
@@ -1,1 +1,7 @@
 (ns user)
+
+(require '[clci.conventional-commit :refer [valid-commit-msg? msg->ast]])
+
+(def commit-msg (slurp ".git/COMMIT_EDITMSG"))
+
+(valid-commit-msg? commit-msg)


### PR DESCRIPTION
This commit fixes the issue of automatically re-adding files that were formatted during the automated git pre-commit workflow. 

See #3 for more information.