### PR TITLE
fix: resolves the issue of invalid cc parser specs #5

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,8 +1,8 @@
 {:paths ["bb" "src/bb"]
- :deps 	{babashka/process      																		 {:mvn/version "0.3.11"}
-         clojure-term-colors/clojure-term-colors  {:mvn/version "0.1.0"}}
+ :deps 	{babashka/process     		 		{:mvn/version "0.3.11"}
+         clojure-term-colors/clojure-term-colors  	{:mvn/version "0.1.0"}}
 
- :pods  {clci/pod    {:path   "./target/clci-0.0.0.main"
+ :pods  {clci/pod    {:path   "./target/clci-0.1.2.main"
 																						:cache  false}}
 
  :tasks {;prepare	{:doc 		""																   :requires     ([tasks :as t])

--- a/build.clj
+++ b/build.clj
@@ -28,7 +28,7 @@
 (defn uberpod
   "Assemble an uberjar from the project to build a babashka pod."
   [_]
-  (clean! nil)
+  ;(clean! nil)
   (b/copy-dir {:src-dirs    src-dirs
                :target-dir  class-dir})
   (b/compile-clj {:basis    basis

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src/clj"]
+{:paths ["src/clj" "src/bb"]
  :description "ClCI"
  :url       "https://github.com/ClockworksIO/clci"
  :scm       {:name "git"
@@ -6,7 +6,8 @@
  :license   {:name "Apache-2.0"
              :url "https://www.apache.org/licenses/LICENSE-2.0"}
  :deps
- {org.clojure/clojure                 {:mvn/version   "1.11.1"}
+ {org.clojure/clojure                       {:mvn/version "1.11.1"}
+  babashka/babashka                         {:mvn/version "1.0.169"}
   instaparse/instaparse 					{:mvn/version "1.4.12"}
   org.endot/bb-pod-racer 					{:mvn/version "0.1.9"}}
 
@@ -21,7 +22,7 @@
                         :ns-default       build}
   }
 
- :build                 {:version         "0.0.0"					; uses semantic versioning!
+ :build                 {:version         "0.1.2"					; uses semantic versioning!
                          :target-dir	   "target" 				; target directory for build artifacts
                          :lib-name        'clockworks/clci}
  }

--- a/manifest.edn
+++ b/manifest.edn
@@ -1,0 +1,10 @@
+{:pod/name clockworks/clci
+ :pod/description "CI tools for Clojure."
+ :pod/version "0.1.2"
+ :pod/license "Apache 2.0"
+ :pod/language "clojure"
+ :pod/artifacts
+ [{:os/name "Linux.*"
+   :os/arch "amd64"
+   :artifact/url "https://github.com/ClockworksIO/clci/archive/refs/tags/v0.1.2.zip"
+   :artifact/executable "clci.main"}]}

--- a/src/clj/clci/conventional_commit.clj
+++ b/src/clj/clci/conventional_commit.clj
@@ -9,22 +9,31 @@
 (def grammar
   "A PEG grammar to validate and parse conventional commit messages."
   (str
-    "<S>		      = 		  TYPE (<'('>SCOPE<')'>)? <':'> <SPACE> SUBJECT ((<EMPTY-LINE> BODY) | (<EMPTY-LINE> BODY <EMPTY-LINE> FOOTER))? GIT-REPORT? <NEWLINE>*;"
-    "TYPE         =       'feat' | 'fix' | 'refactor' | 'perf' | 'style' | 'test' | 'docs' | 'build' | 'ops' | 'chore';"
-    "SCOPE        =       #'[a-zA-Z0-9^\\s]+';"
-    "SUBJECT      =       TEXT ISSUE-REF? TEXT? !'.';"
-    "BODY         =       (BREAKING (TEXT | ISSUE-REF)+) | !BREAKING (TEXT | ISSUE-REF)+;"
-    "FOOTER       =	      (TEXT | ISSUE-REF)+;"
-    "GIT-REPORT   =       <EMPTY-LINE> COMMENT*;"
-    "COMMENT      =       <'#'> #'[^\\n]*' <NEWLINE?> ;"
-    "ISSUE-REF    =       <'#'> ISSUE-ID;"
-    "ISSUE-ID     =       #'([A-Z]+\\-)?[0-9]+';"
-    "BREAKING     =		    <'BREAKING: '> | <'BREAKING CHANGE: '> | <'BREAKING-CHANGE: '>;"
-    "<ASCII-TEXT> =       #'[a-zA-Z0-9]+';"
-    "TEXT     	  =		    #'[^\\n\\#]+';"
-    "SPACE  	    =       ' ';"
-    "NEWLINE      =       '\n';"
-    "EMPTY-LINE   = 		  '\n\n';"))
+    "<S>            =       (HEADER <EMPTY-LINE> FOOTER GIT-REPORT? <NEWLINE>*)
+                            / ( HEADER <EMPTY-LINE> BODY (<EMPTY-LINE> FOOTER)? GIT-REPORT? <NEWLINE>*)
+                            
+                            / (HEADER <EMPTY-LINE> BODY GIT-REPORT? <NEWLINE>*)
+                            / (HEADER GIT-REPORT? <NEWLINE>*);"
+    "<HEADER>       =       TYPE (<'('>SCOPE<')'>)? <':'> <SPACE> SUBJECT;"
+    "TYPE           =       'feat' | 'fix' | 'refactor' | 'perf' | 'style' | 'test' | 'docs' | 'build' | 'ops' | 'chore';"
+    "SCOPE          =       #'[a-zA-Z0-9]+';"
+    "SUBJECT        =       TEXT ISSUE-REF? TEXT? !'.';"
+    "BODY           =       (!PRE-FOOTER PARAGRAPH) / (!PRE-FOOTER PARAGRAPH (<EMPTY-LINE> PARAGRAPH)*);"
+    "PARAGRAPH      =       (ISSUE-REF / TEXT)+;"
+    "PRE-FOOTER     =       NEWLINE+ FOOTER;"
+    "FOOTER         =       FOOTER-ELEMENT (<NEWLINE> FOOTER-ELEMENT)*;"
+    "FOOTER-ELEMENT =       FOOTER-TOKEN <':'> <WHITESPACE> FOOTER-VALUE;"
+    "FOOTER-TOKEN   =       ('BREAKING CHANGE' (<'('>SCOPE<')'>)?) / #'[a-zA-Z\\-^\\#]+';"
+    "FOOTER-VALUE   =       (ISSUE-REF / TEXT)+;"
+    "GIT-REPORT     =       <EMPTY-LINE> COMMENT*;"
+    "COMMENT        =       <'#'> #'[^\\n]*' <NEWLINE?> ;"
+    "ISSUE-REF      =       <'#'> ISSUE-ID;"
+    "ISSUE-ID       =       #'([A-Z]+\\-)?[0-9]+';"
+    "TEXT           =       #'[^\\n\\#]+';"
+    "SPACE          =       ' ';"
+    "WHITESPACE     =       #'\\s';"
+    "NEWLINE        =       <'\n'>;"
+    "EMPTY-LINE     =       <'\n\n'>;"))
 
 
 (defn valid-commit-msg?

--- a/src/clj/user.clj
+++ b/src/clj/user.clj
@@ -1,7 +1,33 @@
 (ns user)
 
-(require '[clci.conventional-commit :refer [valid-commit-msg? msg->ast]])
+(use 'clci.conventional-commit :reload)
 
 (def commit-msg (slurp ".git/COMMIT_EDITMSG"))
 
-(valid-commit-msg? commit-msg)
+(require '[instaparse.core :as insta])
+
+(-> (insta/parser grammar) (insta/parse commit-msg))
+
+
+(def msg 
+(str
+      "feat: switch to new API #RR-33\n\n"
+      "BREAKING CHANGE: With this commit we are switching to the new API. Please update your access token!\n\n"
+      "# Please enter the commit message for your changes. Lines starting\n"
+      "#  with '#' will be ignored, and an empty message aborts the commit.\n"
+      "#\n"
+      "# Date:      Thu Dec 8 17:01:23 2022 +0100\n"
+      "# On branch feat/rr-2\n"
+      "# Changes to be committed:\n"
+      "#       renamed:    ci-bb/src/clj/ci_bb/pod.clj -> ci-bb/src/clj/ci_bb/main.clj")
+  )
+
+
+
+(-> (insta/parser grammar) (insta/parse msg {:trace true :total true}))
+
+(-> (insta/parser grammar) (insta/parses msg))
+
+(-> (insta/parser grammar) (insta/parse msg {:trace true}) (insta/get-failure))
+
+;(= (-> (insta/parser grammar) (insta/parse msg)) result)

--- a/test/clci/conventional_commit_test.clj
+++ b/test/clci/conventional_commit_test.clj
@@ -35,57 +35,208 @@
       [:SUBJECT
        [:TEXT "adding a new awesome feature"]]
       [:BODY
-       [:TEXT "This commit implements the new feature of epic "]
-       [:ISSUE-REF [:ISSUE-ID "RR-111"]]
-       [:TEXT ". It is very good."]])]
+       [:PARAGRAPH
+        [:TEXT "This commit implements the new feature of epic "]
+        [:ISSUE-REF [:ISSUE-ID "RR-111"]]
+        [:TEXT ". It is very good."]]])]
    ;; 6
-   ["fix: resolves input error of #RR-22\n\nThis commit implements a fix of input validation. It is very good :)"
+   ["fix: resolves input error of #RR-22\n\nThis commit implements a fix of input validation. It is very good."
     '([:TYPE "fix"]
       [:SUBJECT
        [:TEXT "resolves input error of "]
        [:ISSUE-REF [:ISSUE-ID "RR-22"]]]
       [:BODY
-       [:TEXT "This commit implements a fix of input validation. It is very good :)"]])]
+       [:PARAGRAPH 
+        [:TEXT "This commit implements a fix of input validation. It is very good."]]])]
    ;; 7
    [(str
+      "fix: resolves input error of #RR-22\n\n"
+      "This commit implements a fix of input validation. It is very good.\n\n"
+      "And another paragraph.\n")
+    '([:TYPE "fix"]
+      [:SUBJECT
+       [:TEXT "resolves input error of "]
+       [:ISSUE-REF [:ISSUE-ID "RR-22"]]]
+      [:BODY
+       [:PARAGRAPH
+        [:TEXT "This commit implements a fix of input validation. It is very good."]]
+       [:PARAGRAPH
+        [:TEXT "And another paragraph."]]])]
+   ;; 8
+   [(str
+      "fix: resolves input error of #RR-22\n\n"
+      "This commit implements a fix of input validation. It is very good.\n\n"
+      "And another paragraph with an issue #RR-123.\n")
+    '([:TYPE "fix"]
+      [:SUBJECT
+       [:TEXT "resolves input error of "]
+       [:ISSUE-REF [:ISSUE-ID "RR-22"]]]
+      [:BODY
+       [:PARAGRAPH
+        [:TEXT "This commit implements a fix of input validation. It is very good."]]
+       [:PARAGRAPH
+        [:TEXT "And another paragraph with an issue "]
+        [:ISSUE-REF [:ISSUE-ID "RR-123"]]
+        [:TEXT "."]]])]
+   ;; 9
+   [(str
+      "fix: resolves input error of #RR-22\n\n"
+      "This commit implements a fix of input validation. It is very good.\n\n"
+      "One more paragraph.\n\n"
+      "And another paragraph with an issue #RR-123.\n")
+    '([:TYPE "fix"]
+      [:SUBJECT
+       [:TEXT "resolves input error of "]
+       [:ISSUE-REF [:ISSUE-ID "RR-22"]]]
+      [:BODY
+       [:PARAGRAPH
+        [:TEXT "This commit implements a fix of input validation. It is very good."]]
+       [:PARAGRAPH
+        [:TEXT "One more paragraph."]]
+       [:PARAGRAPH
+        [:TEXT "And another paragraph with an issue "]
+        [:ISSUE-REF [:ISSUE-ID "RR-123"]]
+        [:TEXT "."]]])]
+   ;; 10
+   [(str
       "feat: switch to new API #RR-33\n\n"
-      "BREAKING: With this commit we are switching to the new API. Please update your access token!\n\n"
-      "See #RR-44 for more details.")
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "BREAKING CHANGE: will not work with library xzy before 0.2.4\n")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
        [:ISSUE-REF [:ISSUE-ID "RR-33"]]]
       [:BODY
-       [:BREAKING]
-       [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]
+       [:PARAGRAPH
+        [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]]
       [:FOOTER
-       [:TEXT "See "]
-       [:ISSUE-REF [:ISSUE-ID "RR-44"]]
-       [:TEXT " for more details."]])]
-   ;; 8
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "BREAKING CHANGE"] 
+        [:FOOTER-VALUE [:TEXT "will not work with library xzy before 0.2.4"]]]])]
+   ;; 11
    [(str
       "feat: switch to new API #RR-33\n\n"
-      "BREAKING: With this commit we are switching to the new API. Please update your access token!\n\n"
-      "See #RR-44 for more details.\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "BREAKING CHANGE: will not work with library xzy before 0.2.4\n"
+      "note: Thanks for all the fish.\n")
+    '([:TYPE "feat"]
+      [:SUBJECT
+       [:TEXT "switch to new API "]
+       [:ISSUE-REF [:ISSUE-ID "RR-33"]]]
+      [:BODY
+       [:PARAGRAPH
+        [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]]
+      [:FOOTER
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "BREAKING CHANGE"] 
+        [:FOOTER-VALUE [:TEXT "will not work with library xzy before 0.2.4"]]]
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "note"] 
+        [:FOOTER-VALUE [:TEXT "Thanks for all the fish."]]]])]
+   ;; 12
+   [(str
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "note: Thanks for all the fish.\n")
+    '([:TYPE "feat"]
+      [:SUBJECT
+       [:TEXT "switch to new API "]
+       [:ISSUE-REF [:ISSUE-ID "RR-33"]]]
+      [:BODY
+       [:PARAGRAPH
+        [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]]
+      [:FOOTER
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "note"] 
+        [:FOOTER-VALUE [:TEXT "Thanks for all the fish."]]]])]
+   ;; 13
+   [(str
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "note: Thanks for all the fish.\n"
+      "more: Don't forget to look at #RR-45!\n")
+    '([:TYPE "feat"]
+      [:SUBJECT
+       [:TEXT "switch to new API "]
+       [:ISSUE-REF [:ISSUE-ID "RR-33"]]]
+      [:BODY
+       [:PARAGRAPH
+        [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]]
+      [:FOOTER
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "note"] 
+        [:FOOTER-VALUE [:TEXT "Thanks for all the fish."]]]
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "more"] 
+        [:FOOTER-VALUE 
+         [:TEXT "Don't forget to look at "] 
+         [:ISSUE-REF [:ISSUE-ID "RR-45"]]
+         [:TEXT "!"]]]])]
+   ;; 14
+   [(str
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "note: Thanks for all the fish.\n"
+      "see-docs: See [the docs](https://www.example.com/foo?id=22&page=3)\n"
+      "more: Don't forget to look at #RR-45!\n")
+    '([:TYPE "feat"]
+      [:SUBJECT
+       [:TEXT "switch to new API "]
+       [:ISSUE-REF [:ISSUE-ID "RR-33"]]]
+      [:BODY
+       [:PARAGRAPH
+        [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]]
+      [:FOOTER
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "note"] 
+        [:FOOTER-VALUE [:TEXT "Thanks for all the fish."]]]
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "see-docs"] 
+        [:FOOTER-VALUE [:TEXT "See [the docs](https://www.example.com/foo?id=22&page=3)"]]]
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "more"] 
+        [:FOOTER-VALUE 
+         [:TEXT "Don't forget to look at "] 
+         [:ISSUE-REF [:ISSUE-ID "RR-45"]]
+         [:TEXT "!"]]]])]
+   ;;;;;
+   ;; 15
+   [(str
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
       "# Please enter a commit message")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
        [:ISSUE-REF [:ISSUE-ID "RR-33"]]]
       [:BODY
-       [:BREAKING]
-       [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]
-      [:FOOTER
-       [:TEXT "See "]
-       [:ISSUE-REF [:ISSUE-ID "RR-44"]]
-       [:TEXT " for more details."]]
+       [:PARAGRAPH
+        [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]]
       [:GIT-REPORT
        [:COMMENT " Please enter a commit message"]])]
-   ;; 9
+   ;; 16
    [(str
       "feat: switch to new API #RR-33\n\n"
-      "BREAKING: With this commit we are switching to the new API. Please update your access token!\n\n"
-      "See #RR-44 for more details.\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "BREAKING CHANGE: will not work with library xzy before 0.2.4\n\n"
+      "# Please enter a commit message")
+    '([:TYPE "feat"]
+      [:SUBJECT
+       [:TEXT "switch to new API "]
+       [:ISSUE-REF [:ISSUE-ID "RR-33"]]]
+      [:BODY
+       [:PARAGRAPH
+        [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]]
+      [:FOOTER
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "BREAKING CHANGE"] 
+        [:FOOTER-VALUE [:TEXT "will not work with library xzy before 0.2.4"]]]]
+      [:GIT-REPORT
+       [:COMMENT " Please enter a commit message"]])]
+   ;; 17
+   [(str
+      "feat: switch to new API #RR-33\n\n"
+      "BREAKING CHANGE: With this commit we are switching to the new API. Please update your access token!\n\n"
       "# Please enter the commit message for your changes. Lines starting\n"
       "#  with '#' will be ignored, and an empty message aborts the commit.\n"
       "#\n"
@@ -97,13 +248,10 @@
       [:SUBJECT
        [:TEXT "switch to new API "]
        [:ISSUE-REF [:ISSUE-ID "RR-33"]]]
-      [:BODY
-       [:BREAKING]
-       [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]
       [:FOOTER
-       [:TEXT "See "]
-       [:ISSUE-REF [:ISSUE-ID "RR-44"]]
-       [:TEXT " for more details."]]
+       [:FOOTER-ELEMENT
+        [:FOOTER-TOKEN "BREAKING CHANGE"]
+        [:FOOTER-VALUE [:TEXT "With this commit we are switching to the new API. Please update your access token!"]]]]
       [:GIT-REPORT
        [:COMMENT " Please enter the commit message for your changes. Lines starting"]
        [:COMMENT "  with '#' will be ignored, and an empty message aborts the commit."]
@@ -112,17 +260,18 @@
        [:COMMENT " On branch feat/rr-2"]
        [:COMMENT " Changes to be committed:"]
        [:COMMENT "       renamed:    ci-bb/src/clj/ci_bb/pod.clj -> ci-bb/src/clj/ci_bb/main.clj"]])]
-   ;; 10
+   ;; 18
    ["chore: this does stuff\n\n"
     '([:TYPE "chore"]
       [:SUBJECT
        [:TEXT "this does stuff"]])]
-   ;; 11
+   ;; 19
    ["fix: this fixes the bug in #123\n\n"
     '([:TYPE "fix"]
       [:SUBJECT
        [:TEXT "this fixes the bug in "]
-       [:ISSUE-REF [:ISSUE-ID "123"]]])]])
+       [:ISSUE-REF [:ISSUE-ID "123"]]])]
+   ])
 
 
 (def invalid-messages
@@ -140,25 +289,22 @@
    ;; 5
    "feat(this!): adding a new awesome feature"
    ;;
-   ;; "feat: Adding a new awesome feature"
+   (str "build: add pod manifest and enable bb lib\n"
+     "\n"
+     "This commit adds a manifest file for the library to be used as a pod and\n"
+     "adds the babashka code to the path to enable use from other\n"
+     "applications.\n\n"
+     "# Please enter the commit message for your changes. Lines starting\n"
+     "# with '#' will be ignored, and an empty message aborts the commit.\n")
    ])
 
 
 (deftest validate-messages
   (testing "Testing to validate correct commit messages."
     (let [parser	(insta/parser grammar)]
-      (is (parseable? parser (get-in valid-messages [0 0])))
-      (is (parseable? parser (get-in valid-messages [1 0])))
-      (is (parseable? parser (get-in valid-messages [2 0])))
-      (is (parseable? parser (get-in valid-messages [3 0])))
-      (is (parseable? parser (get-in valid-messages [4 0])))
-      (is (parseable? parser (get-in valid-messages [5 0])))
-      (is (parseable? parser (get-in valid-messages [6 0])))
-      (is (parseable? parser (get-in valid-messages [7 0])))
-      (is (parseable? parser (get-in valid-messages [8 0])))
-      (is (parseable? parser (get-in valid-messages [9 0])))
-      (is (parseable? parser (get-in valid-messages [10 0]))
-          (is (parseable? parser (get-in valid-messages [11 0])))))))
+      (doseq [[message _] valid-messages]
+        (is (parseable? parser message)))
+      )))
 
 
 (deftest validate-messages-api
@@ -169,26 +315,16 @@
 (deftest parse-messages
   (testing "Testing to parse valid commit messages."
     (let [parser  (insta/parser grammar)]
-      (is (= (parser (get-in valid-messages [0 0])) (get-in valid-messages [0 1])))
-      (is (= (parser (get-in valid-messages [1 0])) (get-in valid-messages [1 1])))
-      (is (= (parser (get-in valid-messages [2 0])) (get-in valid-messages [2 1])))
-      (is (= (parser (get-in valid-messages [3 0])) (get-in valid-messages [3 1])))
-      (is (= (parser (get-in valid-messages [4 0])) (get-in valid-messages [4 1])))
-      (is (= (parser (get-in valid-messages [5 0])) (get-in valid-messages [5 1])))
-      (is (= (parser (get-in valid-messages [6 0])) (get-in valid-messages [6 1])))
-      (is (= (parser (get-in valid-messages [7 0])) (get-in valid-messages [7 1])))
-      (is (= (parser (get-in valid-messages [8 0])) (get-in valid-messages [8 1])))
-      (is (= (parser (get-in valid-messages [9 0])) (get-in valid-messages [9 1])))
-      (is (= (parser (get-in valid-messages [10 0])) (get-in valid-messages [10 1])))
-      (is (= (parser (get-in valid-messages [11 0])) (get-in valid-messages [11 1]))))))
+      (doseq [[message expected] valid-messages]
+        (is (= expected (parser message ))
+          )
+
+        ))))
 
 
 (deftest parse-invalid-messages
   (testing "Testing to parse invalid commit messages. Expect to fail!"
     (let [parser  (insta/parser grammar)]
-      (is (insta/failure? (parser (get invalid-messages 0))))
-      (is (insta/failure? (parser (get invalid-messages 1))))
-      (is (insta/failure? (parser (get invalid-messages 2))))
-      (is (insta/failure? (parser (get invalid-messages 3))))
-      (is (insta/failure? (parser (get invalid-messages 4))))
-      (is (insta/failure? (parser (get invalid-messages 5)))))))
+      (doseq [message invalid-messages]
+        (is (insta/failure? (parser message))))
+      )))


### PR DESCRIPTION
This commit resolves an issue with an invalid implementation of the conventional commit specs. Also adds some pod specific things.

See: #5