### PR TITLE
chore: add kondo as linter #14

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,9 @@
 {:paths ["bb" "src"]
  :deps  {babashka/process     		 		      {:mvn/version "0.3.11"}
          clojure-term-colors/clojure-term-colors  {:mvn/version "0.1.0"}
-         io.github.babashka/instaparse.bb         {:git/sha "0e86a09bafead57eed251cbda53ab35032688bdf"}}
+         io.github.babashka/instaparse.bb         {:git/sha "0e86a09bafead57eed251cbda53ab35032688bdf"}
+         io.github.clj-kondo/clj-kondo-bb         {:git/tag "v2023.01.20" 
+                                                   :git/sha "adfc7df"}}
 
 
  :tasks {test           {:extra-paths       ["test"]
@@ -17,7 +19,7 @@
 	     hooks  	{:doc           "Git hook related commands."
                  	 :requires      ([git-hooks :as gh])
                  	 :task          (apply gh/hooks *command-line-args*)}
-         foo        {:doc       ""
-                     :requires  ([tasks :as t])
-                     :task      t/foo}
+         lint       {:doc           "Run kondo to lint the code. Fail on errors."
+                     :requires      ([utils :as u])
+                     :task          u/kondo-lint}
          }}

--- a/bb/git_hooks.clj
+++ b/bb/git_hooks.clj
@@ -5,7 +5,8 @@
     [clci.conventional-commit :refer [valid-commit-msg?]]
     [clci.git-hooks-utils :refer [spit-hook changed-files]]
     [clojure.term.colors :as c]
-    [format :as fmt]))
+    [format :as fmt]
+    [utils :refer [kondo-lint]]))
 
 
 ;;
@@ -26,6 +27,7 @@
   (println (c/blue "Executing pre-commit hook"))
   (let [files (changed-files)]
     (fmt/format-code "fix")
+    (kondo-lint)
     (doseq [file files]
       (sh (format "git add %s" file)))))
 

--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -1,5 +1,3 @@
 (ns tasks
   "This module defines various tasks that are available to work with the `clci` package.
   This includes perform tests and building the library.")
-
-

--- a/bb/utils.clj
+++ b/bb/utils.clj
@@ -1,0 +1,19 @@
+(ns utils
+  "Utilities"
+  (:require
+    [clj-kondo.core :as clj-kondo]))
+
+
+(defn kondo-lint
+  "Run kondo to lint the code.
+  Raises a non zero exit code if any errors are detected. Takes an optional
+  argument `fail-on-warnings?`. If true the function also raises a non zero
+  exit code when kondo detects any warnings."
+  ([] (kondo-lint false))
+  ([fail-on-warnings?]
+   (let [{:keys [summary] :as results} (clj-kondo/run! {:lint ["src"]})]
+     (clj-kondo/print! results)
+     (when (or
+             (if fail-on-warnings? (pos? (:warning summary)) false)
+             (pos? (:error summary)))
+       (throw (ex-info "Linter failed!" {:babashka/exit 1}))))))


### PR DESCRIPTION
This commit adds kondo as linter. Kondo can either be run as a bb task and it will be run automatically in the pre-commit hook blocking commits if any errors are detected by kondo. See #14 for details.

Resolves #14 