### PR TITLE
feat: use gh api to get and create releases #45

### DIFF
--- a/.carve/ignore
+++ b/.carve/ignore
@@ -34,3 +34,8 @@ clci.tools.ghooks/clj?
 clci.tools.core/lines-of-code
 clci.tools.core/outdated-deps
 clci.tools.core/test-coverage
+clci.gh.core/create-release
+clci.gh.core/get-all-releases
+clci.gh.core/list-releases
+clci.semver/get-release-tags
+clci.semver/derive-current-commit-version

--- a/.cljstyle
+++ b/.cljstyle
@@ -1,3 +1,3 @@
 ;; cljstyle configuration
-{:files {:ignore #{"target" "docs" ".clj-kondo"}}
+{:files {:ignore #{"target" "docs" ".clj-kondo" "cli-tool"}}
  :rules {:blank-lines {:max-consecutive 3}}}

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,4 +1,4 @@
-name: cleanup caches of a branch when the PR is closed
+name: PR closed
 on:
   pull_request:
     types:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: PR
+name: PR updated
 on:
   pull_request:
     types: [opened, synchronize]

--- a/bb.edn
+++ b/bb.edn
@@ -39,6 +39,6 @@
                          :requires     ([build :as b])
                          :task         (apply b/build *command-line-args*)}
          semver         {:doc "semver test"
-                         :requires ([clci.git :as g])
-                         :task g/derive-current-commit-version}
+                         :requires ([clci.semver :as sv])
+                         :task sv/derive-current-commit-version}
          }}

--- a/deps.edn
+++ b/deps.edn
@@ -15,6 +15,7 @@
  :target-dir  "target"
  
  :deps      {babashka/process                         {:mvn/version "0.4.16"}
+             org.babashka/http-client                 {:mvn/version "0.1.4"}
              io.github.babashka/instaparse.bb         {:git/sha "2bdd8726d197abfbe3d943d2c3af547f296a2190"}
              io.github.clj-kondo/clj-kondo-bb         {:git/tag "v2023.01.20" 
                                                        :git/sha "adfc7df"}
@@ -22,12 +23,13 @@
                                                        :git/tag "v0.3.5"
                                                        :git/sha "6f0f3bf"}
              io.github.matthewdowney/linesofcode-bb   {:git/tag "v0.0.2" 
-                                                       :git/sha "12e4f52"}}
+                                                       :git/sha "12e4f52"}
+             cheshire/cheshire                        {:mvn/version "5.11.0"}}
 
  :aliases
- {:format				   {:extra-deps 	{cljfmt                                {:mvn/version "0.9.2"}}}
-  :outdated        {:extra-deps   {com.github.liquidz/antq               {:mvn/version "2.2.992"}}}
-  :coverage        {:extra-deps   {cloverage/cloverage                   {:mvn/version "1.2.4"}}}
-  :nREPL           {:extra-deps   {nrepl/nrepl                           {:mvn/version "1.0.0"}}}
+ {:format				   {:deps 	{mvxcvi/cljstyle                       {:mvn/version "0.15.0"}}}
+  :outdated        {:deps   {com.github.liquidz/antq               {:mvn/version "2.2.992"}}}
+  :coverage        {:deps   {cloverage/cloverage                   {:mvn/version "1.2.4"}}}
+  :nREPL           {:deps   {nrepl/nrepl                           {:mvn/version "1.0.0"}}}
   }
  }

--- a/repo.edn
+++ b/repo.edn
@@ -1,4 +1,12 @@
-{:jobs {:on-commit []}
+{;
+ :scm       {:name    "git"
+             :url     "git@github.com:ClockworksIO/clci.git"
+             :github  {:repo  "clci"
+                       :owner "ClockworksIO"
+             }}
+ ;
+ :jobs {:on-commit []}
+ ;
  :projects 
  [{:root ""
    :extra-jobs {}

--- a/src/clci/conventional_commit.clj
+++ b/src/clci/conventional_commit.clj
@@ -2,40 +2,43 @@
   "This module provides the tools to parse and validate commit messages
   to follow the Conventional Commit Specification."
   (:require
-   [instaparse.core :as insta]))
+    [instaparse.core :as insta]))
+
 
 (def grammar
   "A PEG grammar to validate and parse conventional commit messages."
   (str
-   "<S>            =       (HEADER <EMPTY-LINE> FOOTER GIT-REPORT? <NEWLINE>*)
+    "<S>            =       (HEADER <EMPTY-LINE> FOOTER GIT-REPORT? <NEWLINE>*)
                             / ( HEADER <EMPTY-LINE> BODY (<EMPTY-LINE> FOOTER)? GIT-REPORT? <NEWLINE>*)
                             
                             / (HEADER <EMPTY-LINE> BODY GIT-REPORT? <NEWLINE>*)
                             / (HEADER GIT-REPORT? <NEWLINE>*);"
-   "<HEADER>       =       TYPE (<'('>SCOPE<')'>)? <':'> <SPACE> SUBJECT;"
-   "TYPE           =       'feat' | 'fix' | 'refactor' | 'perf' | 'style' | 'test' | 'docs' | 'build' | 'ci' | 'chore';"
-   "SCOPE          =       #'[a-zA-Z0-9]+';"
-   "SUBJECT        =       TEXT ISSUE-REF? TEXT? !'.';"
-   "BODY           =       (!PRE-FOOTER PARAGRAPH) / (!PRE-FOOTER PARAGRAPH (<EMPTY-LINE> PARAGRAPH)*);"
-   "PARAGRAPH      =       (ISSUE-REF / TEXT / (NEWLINE !NEWLINE))+;"
-   "PRE-FOOTER     =       NEWLINE+ FOOTER;"
-   "FOOTER         =       FOOTER-ELEMENT (<NEWLINE> FOOTER-ELEMENT)*;"
-   "FOOTER-ELEMENT =       FOOTER-TOKEN <':'> <WHITESPACE> FOOTER-VALUE;"
-   "FOOTER-TOKEN   =       ('BREAKING CHANGE' (<'('>SCOPE<')'>)?) / #'[a-zA-Z\\-^\\#]+';"
-   "FOOTER-VALUE   =       (ISSUE-REF / TEXT)+;"
-   "GIT-REPORT     =       (<EMPTY-LINE> / <NEWLINE>) COMMENT*;"
-   "COMMENT        =       <'#'> #'[^\\n]*' <NEWLINE?> ;"
-   "ISSUE-REF      =       <'#'> ISSUE-ID;"
-   "ISSUE-ID       =       #'([A-Z]+\\-)?[0-9]+';"
-   "TEXT           =       #'[^\\n\\#]+';"
-   "SPACE          =       ' ';"
-   "WHITESPACE     =       #'\\s';"
-   "NEWLINE        =       <'\n'>;"
-   "EMPTY-LINE     =       <'\n\n'>;"))
+    "<HEADER>       =       TYPE (<'('>SCOPE<')'>)? <':'> <SPACE> SUBJECT;"
+    "TYPE           =       'feat' | 'fix' | 'refactor' | 'perf' | 'style' | 'test' | 'docs' | 'build' | 'ci' | 'chore';"
+    "SCOPE          =       #'[a-zA-Z0-9]+';"
+    "SUBJECT        =       TEXT ISSUE-REF? TEXT? !'.';"
+    "BODY           =       (!PRE-FOOTER PARAGRAPH) / (!PRE-FOOTER PARAGRAPH (<EMPTY-LINE> PARAGRAPH)*);"
+    "PARAGRAPH      =       (ISSUE-REF / TEXT / (NEWLINE !NEWLINE))+;"
+    "PRE-FOOTER     =       NEWLINE+ FOOTER;"
+    "FOOTER         =       FOOTER-ELEMENT (<NEWLINE> FOOTER-ELEMENT)*;"
+    "FOOTER-ELEMENT =       FOOTER-TOKEN <':'> <WHITESPACE> FOOTER-VALUE;"
+    "FOOTER-TOKEN   =       ('BREAKING CHANGE' (<'('>SCOPE<')'>)?) / #'[a-zA-Z\\-^\\#]+';"
+    "FOOTER-VALUE   =       (ISSUE-REF / TEXT)+;"
+    "GIT-REPORT     =       (<EMPTY-LINE> / <NEWLINE>) COMMENT*;"
+    "COMMENT        =       <'#'> #'[^\\n]*' <NEWLINE?> ;"
+    "ISSUE-REF      =       <'#'> ISSUE-ID;"
+    "ISSUE-ID       =       #'([A-Z]+\\-)?[0-9]+';"
+    "TEXT           =       #'[^\\n\\#]+';"
+    "SPACE          =       ' ';"
+    "WHITESPACE     =       #'\\s';"
+    "NEWLINE        =       <'\n'>;"
+    "EMPTY-LINE     =       <'\n\n'>;"))
+
 
 (def parser
   "Setup a parser for Conventional Commit messages."
   (insta/parser grammar))
+
 
 (defn valid-commit-msg?
   "Predicate that takes a commit `msg` as string and returns true if the message satisfies the
@@ -46,6 +49,7 @@
       (insta/failure?)
       (not)))
 
+
 (defn parse-only-valid
   "Takes a collection of commit `messages` and tries to parse them.
   All messages that can not get parsed are discarded and a collection
@@ -55,11 +59,13 @@
        (map #(insta/parse parser %))
        (remove insta/failure?)))
 
+
 (defn msg->ast
   "Get the AST from a commit `msg`."
   [msg]
   (-> parser
       (insta/parse msg)))
+
 
 (defn subtree-by-token
   "Implements a depth-first search on the abstract syntax `tree` to find
@@ -76,17 +82,20 @@
       (empty? tail)           nil
       :else                   (subtree-by-token tail token))))
 
+
 (defn get-type
   "Get the type of a CC message.
   Takes the abstract syntax `tree` of the message and returns the type as string."
   [tree]
   (-> (subtree-by-token tree :TYPE) first))
 
+
 (defn get-scope
   "Get the scope of a CC message.
   Takes the abstract syntax `tree` of the message and returns the scope as string or nil."
   [tree]
   (-> (subtree-by-token tree :SCOPE) first))
+
 
 (defn is-breaking?
   "Test if the CC message has breaking changes.

--- a/src/clci/gh/core.clj
+++ b/src/clci/gh/core.clj
@@ -1,0 +1,122 @@
+(ns clci.gh.core
+  "This module provides several functions to interact with Github
+	using the official Github REST API.
+  This module contains code based on https://github.com/borkdude/gh-release-artifact"
+  (:require
+    [babashka.http-client :as http]
+    [cheshire.core :as cheshire]
+    [clci.git :as git]
+    [clojure.string :as str]))
+
+
+(defn- gh-token
+  "Get the Github access token from the environment."
+  []
+  (System/getenv "GITHUB_TOKEN"))
+
+
+(defn- path
+  "Build a path from a vector of `parts` (strings)."
+  [& parts]
+  (str/join "/" parts))
+
+
+(defn- ->query-string
+  "Takes a map `params` of key-value pairs and builds an url
+  query string from it."
+  [params]
+  (->> (map
+         (fn [[k v]] (str (name k) "=" v))
+         params)
+       (str/join "&")))
+
+
+(def endpoint
+  "Github REST APIendpoint."
+  "https://api.github.com")
+
+
+(defn- release-endpoint
+  "Get the release endpoint for a given `owner` and `repo`."
+  [owner repo]
+  (path endpoint "repos" owner repo "releases"))
+
+
+(defn- with-headers
+  "Add the gh authorization token to the request `req`."
+  [req]
+  (update req :headers assoc
+          "Authorization" (str "token " (gh-token))
+          "Accept" "application/vnd.github.v3+json"
+          "X-GitHub-Api-Version" "2022-11-28"))
+
+
+(defn- with-query-params
+  "Add query params to a given base url."
+  [base-url params]
+  (str base-url "?" (->query-string params)))
+
+
+(defn list-releases
+  "Get a list of all releases.
+  Takes the name of the `owner` and the name of the `repo`.
+  Optionally takes either a third `limit` parameter which is an int from 1..100
+  to limit the number of releases fetched from the server.
+  When fetching the last 100 releases is not enough the function can be called with four
+  arguments: `owner`, `repo`, `paer-page` and `page` where per-page is the number of
+  results per page and page is the page number to fetch."
+  ([owner repo] (list-releases owner repo 30))
+  ([owner repo limit] (list-releases owner repo limit 1))
+  ([owner repo per-page page]
+   (-> (http/get (with-query-params (release-endpoint owner repo) {:per_page per-page :page page})
+                 (with-headers {}))
+       :body
+       (cheshire/parse-string true))))
+
+
+(defn get-latest-release
+  "Get the latest release.
+  Takes the name of the `owner` and the name of the `repo`."
+
+  [owner repo]
+  (-> (http/get (path (release-endpoint owner repo) "latest")
+                (with-headers {}))
+      :body
+      (cheshire/parse-string true)))
+
+
+(defn create-release
+  "Create a new release.
+  Takes the following argument map:
+  | key                 | description                         |
+  | --------------------|-------------------------------------|
+  | `:owner`            | (required!) Owner of the repository.
+  | `:repo`             | (required!) Name of the repository.
+  | `:tag`              | (required!) Name of the tag for the release. Should follow SemVer!.
+  | `:commit`           | (optional) SHA of the commit of the release. When not provided, the current commit is used.
+  | `:draft`            | (optional) If true, the release is marked as draft. Defaults to true.
+  | `:pre-release`      | (optional) If true, the release is marked as a pre-release.
+  | `:target-commitish` | (optional) Specifies the commitish value that determines where the Git tag is created from.`"
+  [{:keys [owner repo tag commit draft pre-release target-commitish]
+    :or   {draft  true
+           target-commitish (or commit (git/current-commit))}}]
+  (-> (http/post (release-endpoint owner repo)
+                 (with-headers
+                   {:body (cheshire/generate-string (cond-> {:tag_name tag
+                                                             :name tag
+                                                             :draft draft}
+                                                      target-commitish (assoc :target_commitish target-commitish)
+                                                      pre-release      (assoc :prerelease pre-release)))}))
+      :body
+      (cheshire/parse-string true)))
+
+
+(defn get-tag
+  "Get a tag object.
+  Takes the `owner` and the `repo` name and the `tag`."
+  [owner repo tag]
+  (-> (http/get (path endpoint "repos" owner repo "git" "ref" "tags" tag)
+                (with-headers {}))
+      :body
+      (cheshire/parse-string true)))
+

--- a/src/clci/git.clj
+++ b/src/clci/git.clj
@@ -1,55 +1,25 @@
 (ns clci.git
   "Various git tooling."
   (:require
-   [babashka.process :refer [sh shell]]
-   [clci.conventional-commit :as cc]
-   [clci.semver :as sv]
-   [clojure.string :as str]))
+    [babashka.process :refer [sh shell]]
+    [clojure.string :as str]))
 
-(defn get-release-tags
-  "Get a list of all release tags.
-  A release tag must follow the semantic versioning.
-  examples:
-  - `1.0.3`
-  - `1.2.0-pre-20230103`
-  - `1.2.3-ac3619f0d7`"
+
+(defn get-tags
+  "Get a list of all tags."
   []
-  (as-> (shell {:out :string} "git tag") $
-    (:out $)
-    (str/split-lines $)
-    (filter (fn [tag] (re-matches sv/semver-re tag)) $)))
+  (-> (shell {:out :string} "git tag")
+      :out
+      str/split-lines))
 
-;; (defn latest-release
-;;   "Get the latest release.
-;;   The latest release is the one with the highest version number."
-;;   [releases]
-;;   (-> (v/version-sort releases)
-;;       last))
 
-(defn get-latest-release
-  "Fake Adapter to get the latest release.
-  TODO: Use the proper GH API for this instead!"
-  []
-  {:commit  "4d38687e63c8de636c5aa2b475e6c337b9b9f4f1"
-   :tag     "0.3.1"
-   :name    "Version 0.3.1"})
-
-(defn derive-release-version
-  "Get the version of the given `release` in a convenient vec format.
-  Returns a vector in the format `[major minor patch pre-release]` where
-  the first three parts are integers and the pre-release part is a string."
-  [release]
-  [(sv/major (:tag release))
-   (sv/minor (:tag release))
-   (sv/patch (:tag release))
-   (sv/pre-release (:tag release))])
-
-(defn latest-commit
-  "Get the latest commit on the current branch."
+(defn current-commit
+  "Get the current commit on the current branch."
   []
   (-> (sh "git" "rev-parse" "HEAD")
       :out
       str/trim))
+
 
 (defn commits-on-branch-since
   "Get all commits using git cli.
@@ -57,7 +27,7 @@
   | key          | description |
   | -------------|-------------|
   | `:branch`    | (optional) The branch to get the commits. Defaults to `master`
-  | `:since`     | (optional) Commit ID since when to get all commits. Defaults to the first commit on the branch.
+  | `:since`     | (optional) Commit SHA since when to get all commits. Defaults to the first commit on the branch.
   | `:with-tags` | (optional) When set, the log will include commits that add a tag. Defaults to `false`.
   "
   ([] (commits-on-branch-since {}))
@@ -75,56 +45,18 @@
                               :files   (subvec v 4)})
          ;; git shell command used to get the log in the format required
          cmd (str/join
-              " "
-              ["git log --format=\"%n%n%n%H%n%ai%n%ae%n%s\""
-               "--name-only"
-               (when-not with-tags "--decorate-refs-exclude=refs/tags")
-               (format "--first-parent %s" branch)
-               (when since (format "%s..HEAD" since))])]
+               " "
+               ["git log --format=\"%n%n%n%H%n%ai%n%ae%n%s\""
+                "--name-only"
+                (when-not with-tags "--decorate-refs-exclude=refs/tags")
+                (format "--first-parent %s" branch)
+                (when since (format "%s..HEAD" since))])]
      (as-> (shell {:out :string} cmd) $
-       (:out $)
-       (str/split $ #"\n\n\n")
-       (remove str/blank? $)
-       (map
-        (comp commit-col->map (partial into []) #(remove str/blank? %) str/split-lines)
-        $)))))
+           (:out $)
+           (str/split $ #"\n\n\n")
+           (remove str/blank? $)
+           (map
+             (comp commit-col->map (partial into []) #(remove str/blank? %) str/split-lines)
+             $)))))
 
-(defn- dervice-version-from-commits
-  "Derive a version based on an inital version and a list of commits.
-  Takes the `inital-version` as a 4-tuple vector and a `commits` list with pairs
-  `[type breaking?]`. The _type_ denotes the change type as a string and the 
-  _breaking?_ boolean flag indicates if the change is marked as breaking. 
-  The commits are ordered newest-commit...oldest-commit."
-  [inital-version commits]
-  (let [inc-major   (fn [[ma _ _ _]] [(inc ma) 0 0 nil])
-        inc-minor   (fn [[ma mi _ _]] [ma (inc mi) 0 nil])
-        inc-patch   (fn [[ma mi p _]] [ma mi (inc p) nil])
-        inc-version (fn [[t b?] v]
-                      (cond
-                        b?            (inc-major v)
-                        (= t "feat")  (inc-minor v)
-                        (= t "fix")   (inc-patch v)
-                        :else         v))]
-    (reduce
-     (fn [acc commit] (inc-version commit acc))
-     inital-version
-     (reverse commits))))
 
-(defn derive-current-commit-version
-  "Derive the version of the current codebase.
-  Uses the latest release that exists and the git log which must follow the conventional commits
-  specification. Depending on the type of the commit the new version will be calculated
-  following the semantic versioning specs."
-  []
-  (let [;; get the last release using the gh api
-        last-release          (get-latest-release)
-        ;; we need the version as an easy to manipulate datastructure, not just as string
-        last-release-version  (derive-release-version last-release)
-        ;; get a git log of all commits since the latest release
-        commit-log            (commits-on-branch-since {:since (:commit last-release)})
-        ;; parse the git log entries, discard those not following the conventional commit specs
-        semver-entries        (cc/parse-only-valid (map :subject commit-log))
-        ;; extract the type of the commits and if they have a breaking change
-        commit-types          (map (fn [e] [(cc/get-type e) (cc/is-breaking? e)]) semver-entries)]
-    ;; using all information we collected we can now calculate the new version
-    (dervice-version-from-commits last-release-version commit-types)))

--- a/src/clci/proc_wrapper.clj
+++ b/src/clci/proc_wrapper.clj
@@ -2,11 +2,13 @@
   "Taken from: https://github.com/babashka/nbb/blob/proc-wrapper/script/proc_wrapper.clj
   as a result of this discussion https://github.com/babashka/process/discussions/102."
   (:require
-   [babashka.process :as process :refer [process]]
-   [clci.term :refer [with-c]]
-   [clojure.string :as str]))
+    [babashka.process :as process :refer [process]]
+    [clci.term :refer [with-c]]
+    [clojure.string :as str]))
+
 
 (def output-lock (Object.))
+
 
 (defn- output-wrapper
   [stream prefix writer]
@@ -36,11 +38,13 @@
                               buffer)))
             (recur)))))))
 
+
 #_(defn output-wrapper [stream prefix writer]
     (let [rdr (io/reader stream)
           lines (line-seq rdr)]
       (run! #(binding [*out* writer]
                (println prefix %)) lines)))
+
 
 (defn wrap-process
   "Wrap a Process output.
@@ -56,6 +60,7 @@
      @output-out
      @output-err
      checked)))
+
 
 (comment
   "example use:"

--- a/src/clci/semver.clj
+++ b/src/clci/semver.clj
@@ -1,7 +1,12 @@
 (ns clci.semver
   "Semantic Versioning related functionality."
   (:require
-   [clojure.string :as str]))
+    [clci.conventional-commit :as cc]
+    [clci.gh.core :as gh]
+    [clci.git :as git]
+    [clci.util :refer [read-repo]]
+    [clojure.string :as str]))
+
 
 (def semver-re
   "Regular Expression to match version strings following the
@@ -9,11 +14,13 @@
   See https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string."
   #"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
 
+
 (defn valid-version-tag?
   "Predicate to test if the given `tag` contains a string that follows
   the semantic versioning convention."
   [tag]
   (some? (re-matches semver-re tag)))
+
 
 (defn major
   "Get the major part of the version."
@@ -23,6 +30,7 @@
         (first)
         (Integer/parseInt))))
 
+
 (defn minor
   "Get the minor part of the version."
   [version]
@@ -30,6 +38,7 @@
     (-> (str/split version #"\.|-")
         (second)
         (Integer/parseInt))))
+
 
 (defn patch
   "Get the patch part of the version."
@@ -39,9 +48,89 @@
         (nth 2)
         (Integer/parseInt))))
 
+
 (defn pre-release
   "Get the pre-release part of the version - if any."
   [version]
   (when (re-matches semver-re version)
     (-> (str/split version #"-" 2)
         (get 1 nil))))
+
+
+(defn- get-latest-release
+  "Adapter to get the latest release.
+  **Note**: Only supports the Github API to get the latest release at this time."
+  []
+  (let [repo-conf   (read-repo)
+        repo        (get-in repo-conf [:scm :github :repo])
+        owner       (get-in repo-conf [:scm :github :owner])
+        release     (gh/get-latest-release owner repo)
+        tag         (gh/get-tag owner repo (:tag_name release))]
+    {:commit  (get-in tag [:object :sha])
+     :tag     (:tag_name release)
+     :name    (:name release)}))
+
+
+(defn- get-release-tags
+  "Get a list of all release tags.
+  A release tag must follow the semantic versioning.
+  examples:
+  - `1.0.3`
+  - `1.2.0-pre-20230103`
+  - `1.2.3-ac3619f0d7`"
+  []
+  (filter (fn [tag] (re-matches semver-re tag)) (git/get-tags)))
+
+
+(defn- derive-release-version
+  "Get the version of the given `release` in a convenient vec format.
+  Returns a vector in the format `[major minor patch pre-release]` where
+  the first three parts are integers and the pre-release part is a string.
+  A `release` must be a map with the keys :commit, :tag and :name."
+  [release]
+  [(major (:tag release))
+   (minor (:tag release))
+   (patch (:tag release))
+   (pre-release (:tag release))])
+
+
+(defn- dervice-version-from-commits
+  "Derive a version based on an inital version and a list of commits.
+  Takes the `inital-version` as a 4-tuple vector and a `commits` list with pairs
+  `[type breaking?]`. The _type_ denotes the change type as a string and the 
+  _breaking?_ boolean flag indicates if the change is marked as breaking. 
+  The commits are ordered newest-commit...oldest-commit."
+  [inital-version commits]
+  (let [inc-major   (fn [[ma _ _ _]] [(inc ma) 0 0 nil])
+        inc-minor   (fn [[ma mi _ _]] [ma (inc mi) 0 nil])
+        inc-patch   (fn [[ma mi p _]] [ma mi (inc p) nil])
+        inc-version (fn [[t b?] v]
+                      (cond
+                        b?            (inc-major v)
+                        (= t "feat")  (inc-minor v)
+                        (= t "fix")   (inc-patch v)
+                        :else         v))]
+    (reduce
+      (fn [acc commit] (inc-version commit acc))
+      inital-version
+      (reverse commits))))
+
+
+(defn derive-current-commit-version
+  "Derive the version of the current codebase.
+  Uses the latest release that exists and the git log which must follow the conventional commits
+  specification. Depending on the type of the commit the new version will be calculated
+  following the semantic versioning specs."
+  []
+  (let [;; get the last release using the gh api
+        last-release          (get-latest-release)
+        ;; we need the version as an easy to manipulate datastructure, not just as string
+        last-release-version  (derive-release-version last-release)
+        ;; get a git log of all commits since the latest release
+        commit-log            (git/commits-on-branch-since {:since (:commit last-release)})
+        ;; parse the git log entries, discard those not following the conventional commit specs
+        semver-entries        (cc/parse-only-valid (map :subject commit-log))
+        ;; extract the type of the commits and if they have a breaking change
+        commit-types          (map (fn [e] [(cc/get-type e) (cc/is-breaking? e)]) semver-entries)]
+    ;; using all information we collected we can now calculate the new version
+    (dervice-version-from-commits last-release-version commit-types)))

--- a/src/clci/term.clj
+++ b/src/clci/term.clj
@@ -1,6 +1,7 @@
 (ns clci.term
   "Utilities for the terminal.")
 
+
 ;;
 ;; Set colors for text in the terminal
 ;; Based on: https://github.com/trhura/clojure-term-colors by github user 'trhura'
@@ -12,9 +13,11 @@
   [i]
   (str "\033[" i "m"))
 
+
 (def colors'
   "All available colors by their name."
   [:grey :red :green :yellow :blue :magenta :cyan :white])
+
 
 (def colors
   "Color map for text."
@@ -22,15 +25,18 @@
           (map escape-code
                (range 30 38))))
 
+
 (def highlights
   "Color map for text highlights."
   (zipmap colors'
           (map escape-code
                (range 40 48))))
 
+
 (def reset
   "Escape code"
   (escape-code 0))
+
 
 (defn with-c
   "Build a text string with a specific color.
@@ -38,46 +44,55 @@
   ([c s] (with-c c s false))
   ([c s no-reset] (if no-reset (str (get colors c) s) (str (get colors c) s reset))))
 
+
 (defn with-h
   "Build a text string with a specific highlight color.
 	Resets to the default color after the text if not explicitly forbidden."
   ([c s] (with-h c s false))
   ([c s no-reset] (if no-reset (str (get highlights c) s) (str (get highlights c) s reset))))
 
+
 (defn grey
   "Shorthand for `(with-color :grey s)`."
   ([s] (with-c :grey s))
   ([s no-reset] (with-c :grey s no-reset)))
+
 
 (defn red
   "Shorthand for `(with-color :red s)`."
   ([s] (with-c :red s))
   ([s no-reset] (with-c :red s no-reset)))
 
+
 (defn green
   "Shorthand for `(with-color :green s)`."
   ([s] (with-c :green s))
   ([s no-reset] (with-c :green s no-reset)))
+
 
 (defn yellow
   "Shorthand for `(with-color :yellow s)`."
   ([s] (with-c :yellow s))
   ([s no-reset] (with-c :yellow s no-reset)))
 
+
 (defn blue
   "Shorthand for `(with-color :blue s)`."
   ([s] (with-c :blue s))
   ([s no-reset] (with-c :blue s no-reset)))
+
 
 (defn magenta
   "Shorthand for `(with-color :magenta s)`."
   ([s] (with-c :magenta s))
   ([s no-reset] (with-c :magenta s no-reset)))
 
+
 (defn cyan
   "Shorthand for `(with-color :cyan s)`."
   ([s] (with-c :cyan s))
   ([s no-reset] (with-c :cyan s no-reset)))
+
 
 (defn white
   "Shorthand for `(with-color :white s)`."

--- a/src/clci/tools/antq.clj
+++ b/src/clci/tools/antq.clj
@@ -1,9 +1,10 @@
 (ns clci.tools.antq
   ""
   (:require
-   [babashka.cli :as cli]
-   [clci.term :as c]
-   [babashka.process :refer [sh]]))
+    [babashka.cli :as cli]
+    [babashka.process :refer [sh]]
+    [clci.term :as c]))
+
 
 (def cli-options
   ""
@@ -14,14 +15,17 @@
     :upgrade	{:coerce :boolean :desc "Run antq and upgrade all outdated dependencies automatically."}
     :help  		{:coerce :boolean :desc "Show help."}}})
 
+
 (defn- print-help
   "Print help for the antq task."
   []
   (println "Check for outdated dependencies.\n")
   (println (cli/format-opts cli-options)))
 
+
 ;; Method to handle antq task.
 (defmulti find-outdated-impl (fn [& args] (first args)))
+
 
 ;; Check dependencies for outdated - don't upgrade!.
 (defmethod find-outdated-impl :check [_ opts]
@@ -36,6 +40,7 @@
     (when write-report?
       (println (c/magenta "REPORT NOT IMPLEMENTED YET!")))))
 
+
 ;; Check dependencies for outdated and upgrade.
 (defmethod find-outdated-impl :upgrade [_ opts]
   (let [write-report?   (:report opts)
@@ -49,9 +54,11 @@
     (when write-report?
       (println (c/magenta "REPORT NOT IMPLEMENTED YET!")))))
 
+
 ;; Default handler to catch unknown formatter commands.
 (defmethod find-outdated-impl :default [& _]
   (print-help))
+
 
 (defn find-outdated-dependencies
   ""

--- a/src/clci/tools/carve.clj
+++ b/src/clci/tools/carve.clj
@@ -4,12 +4,13 @@
   and dead code from a project. The module defines an api how to
   use carve in an easy way from a bb task."
    (:require
-    [babashka.cli :as cli]
-    [carve.api :as api]
-    [clci.term :as c]
-    [clci.util :refer [get-paths]]
-    [clojure.edn :as edn]
-    [clojure.pprint :refer [pprint]]))
+     [babashka.cli :as cli]
+     [carve.api :as api]
+     [clci.term :as c]
+     [clci.util :refer [get-paths]]
+     [clojure.edn :as edn]
+     [clojure.pprint :refer [pprint]]))
+
 
 (def cli-options
   "Available cli options for carve."
@@ -22,13 +23,16 @@
     :interactive  {:coerce :boolean :desc "Interactive mode: ask what to do with an unused var."}
     :help         {:coerce :boolean :desc "Show help."}}})
 
+
 (defn- print-help
   "Print help for the carve task."
   []
   (println "Run carve to remove unused vars.\n")
   (println (cli/format-opts cli-options)))
 
+
 (defmulti carve-impl (fn [& args] (first args)))
+
 
 ;; Run carve in check mode - the code won't be changed but a
 ;; report may be created and a non zero exit code may be returned
@@ -53,6 +57,7 @@
     (when (and failure? (not no-fail?))
       (System/exit 1))))
 
+
 ;; Run carve in fix mode - use with care!
 (defmethod carve-impl :fix [_]
   (println (c/blue "Running Carve in fix mode"))
@@ -60,14 +65,17 @@
     (println (c/yellow "Carve fixed the following issues:"))
     (pprint report)))
 
+
 ;; Run carve in interactive mode - useful during development on a local machine
 (defmethod carve-impl :interactive [_]
   (println (c/blue "Running Carve in interactive mode"))
   (api/carve! {:paths (get-paths) :interactive true}))
 
+
 ;; Print help
 (defmethod carve-impl :help [_]
   (print-help))
+
 
 (defn carve!
   "Run carve to identify and optionally remove unused vars."

--- a/src/clci/tools/cloverage.clj
+++ b/src/clci/tools/cloverage.clj
@@ -1,9 +1,10 @@
 (ns clci.tools.cloverage
   "Tool wrapper of cloverave to get the test coverage of the code."
   (:require
-   [babashka.cli :as cli]
-   [clci.term :as c]
-   [babashka.process :refer [sh]]))
+    [babashka.cli :as cli]
+    [babashka.process :refer [sh]]
+    [clci.term :as c]))
+
 
 (def cli-options
   ""
@@ -14,11 +15,13 @@
     :silent   	{:coerce :boolean :desc "Set to true if you would like to not write anything to stdout when running in a CI environment."}
     :help  			{:coerce :boolean :desc "Show help."}}})
 
+
 (defn- print-help
   "Print help for the task."
   []
   (println "Calculate code test coverage using 'cloverage'.\n")
   (println (cli/format-opts cli-options)))
+
 
 (defn- cloverage-impl
   "Implementation of the cloverage execution."
@@ -28,8 +31,8 @@
         src-path        (:src-path opts)
         test-path       (:test-path opts)
         result   				(sh
-                      {:out :string :err :string}
-                      (format "clj -M:coverage -m cloverage.coverage -p %s -s %s --text" src-path test-path))
+                       {:out :string :err :string}
+                       (format "clj -M:coverage -m cloverage.coverage -p %s -s %s --text" src-path test-path))
         report          (-> result :out)]
     ;; write report to stdout if not supressed
     (when-not silent?
@@ -37,6 +40,7 @@
     ;; write a report if requested
     (when write-report?
       (println (c/magenta "REPORT NOT IMPLEMENTED YET!")))))
+
 
 (defn cloverage
   ""

--- a/src/clci/tools/core.clj
+++ b/src/clci/tools/core.clj
@@ -2,49 +2,57 @@
   "This modules exposes an api of several tools that can be used
   directly from a bb task in a project's codebase."
   (:require
-   [clci.tools.carve :as carve]
-   [clci.tools.linter :as linter]
-   [clci.tools.mkdocs :as mkdocs]
-   [clci.tools.ghooks :as gh]
-   [clci.tools.format :as fmt]
-   [clci.tools.linesofcode :as loc]
-   [clci.tools.antq :as aq]
-   [clci.tools.cloverage :as cov]))
+    [clci.tools.antq :as aq]
+    [clci.tools.carve :as carve]
+    [clci.tools.cloverage :as cov]
+    [clci.tools.format :as fmt]
+    [clci.tools.ghooks :as gh]
+    [clci.tools.linesofcode :as loc]
+    [clci.tools.linter :as linter]
+    [clci.tools.mkdocs :as mkdocs]))
+
 
 (defn lint
   "Lint the code."
   [opts]
   (linter/lint opts))
 
+
 (defn carve!
   "Find and optionally remove unused vars from the codebase."
   [opts]
   (carve/carve! opts))
+
 
 (defn docs!
   "Build a documentation with mkdocs."
   [opts]
   (mkdocs/docs! opts))
 
+
 (defn git-hooks
   "Run a git hook."
   [opts]
   (gh/hook opts))
+
 
 (defn format!
   "Run the formatter on all Clojure files."
   [opts]
   (fmt/format! opts))
 
+
 (defn lines-of-code
   "Get the lines of code of the project."
   [opts]
   (loc/lines-of-code opts))
 
+
 (defn outdated-deps
   "Find outdated dependencies."
   [opts]
   (aq/find-outdated-dependencies opts))
+
 
 (defn test-coverage
   "Get the test coverage of the project's code."

--- a/src/clci/tools/format.clj
+++ b/src/clci/tools/format.clj
@@ -1,11 +1,12 @@
 (ns clci.tools.format
   "This module provides a task to check and fix code formatting using [cljfmt](https://github.com/weavejester/cljfmt)."
   (:require
-   [clojure.string :as str]
-   [clojure.pprint :refer [pprint]]
-   [babashka.process :refer [sh]]
-   [babashka.cli :as cli]
-   [clci.term :as c]))
+    [babashka.cli :as cli]
+    [babashka.process :refer [sh]]
+    [clci.term :as c]
+    [clojure.pprint :refer [pprint]]
+    [clojure.string :as str]))
+
 
 (def cli-options
   ""
@@ -17,14 +18,17 @@
     :fix  		{:coerce :boolean :desc "Run the formatter and automatically fix all style violations."}
     :help  		{:coerce :boolean :desc "Show help."}}})
 
+
 (defn- print-help
   "Print help for the format task."
   []
   (println "Run the code formatter.\n")
   (println (cli/format-opts cli-options)))
 
+
 ;; Method to handle formatter tasks.
 (defmulti format-code-impl (fn [& args] (first args)))
+
 
 ;; Check the style of all Clojure files.
 (defmethod format-code-impl :check [_ opts]
@@ -33,7 +37,7 @@
         no-fail?        (:no-fail opts)
         _								(when-not silent?
                    (println (c/blue "Checking Clojure file style...")))
-        result   				(sh {:out :string :err :string} "clj -M:format -m cljfmt.main check")
+        result   				(sh {:out :string :err :string} "clj -M:format -m cljstyle.main check")
         failure?				(not= 0 (:exit result))
         report          (-> result :err str/split-lines)]
     ;; write report to stdout if not supressed
@@ -46,19 +50,22 @@
     (when (and failure? (not no-fail?))
       (System/exit 1))))
 
+
 ;; Fix the style of all Clojure files.
 (defmethod format-code-impl :fix [_ opts]
   (println (c/blue "Checking Clojure file style..."))
-  (let [result   				(sh {:out :string :err :string} "clj -M:format -m cljfmt.main fix")
+  (let [result   				(sh {:out :string :err :string} "clj -M:format -m cljstyle.main fix")
         failure?				(not= 0 (:exit result))
         report          (-> result :err str/split-lines)]
     (pprint report)
     (when failure?
       (System/exit 1))))
 
+
 ;; Default handler to catch unknown formatter commands.
 (defmethod format-code-impl :default [& _]
   (print-help))
+
 
 (defn format!
   "Implementation wrapper to format clojure code."

--- a/src/clci/tools/linesofcode.clj
+++ b/src/clci/tools/linesofcode.clj
@@ -1,10 +1,11 @@
 (ns clci.tools.linesofcode
   "Implementation of the tool to get the lines of code"
   (:require
-   [babashka.cli :as cli]
-   [com.mjdowney.loc :as loc]
-   [clci.term :as c]
-   [clci.util :refer [get-paths]]))
+    [babashka.cli :as cli]
+    [clci.term :as c]
+    [clci.util :refer [get-paths]]
+    [com.mjdowney.loc :as loc]))
+
 
 (def cli-options
   "Available cli options for carve."
@@ -13,11 +14,13 @@
     :silent       {:coerce :boolean :desc "Set to true if you would like to not write anything to stdout when running the tool i.e. in a CI environment."}
     :help         {:coerce :boolean :desc "Show help."}}})
 
+
 (defn- print-help
   "Print help for the carve task."
   []
   (println "Get the lines of code of the project's code base.\n")
   (println (cli/format-opts cli-options)))
+
 
 (defn- lines-of-code-impl
   [opts]
@@ -29,6 +32,7 @@
       (print report))
     (when write-report?
       (println (c/magenta "REPORT NOT IMPLEMENTED YET!")))))
+
 
 (defn lines-of-code
   "Run linesofcode-bb to get the lines of code."

--- a/src/clci/tools/linter.clj
+++ b/src/clci/tools/linter.clj
@@ -2,8 +2,9 @@
   "Implementation of the linter. Uses the `clj-kondo` library
 	and defines some sane abstractions how to use it from a bb task."
   (:require
-   [babashka.cli :as cli]
-   [clj-kondo.core :as clj-kondo]))
+    [babashka.cli :as cli]
+    [clj-kondo.core :as clj-kondo]))
+
 
 (defn- lint-impl
   "Run kondo to lint the code.
@@ -24,6 +25,7 @@
       :else
       nil)))
 
+
 (def cli-options
   "Available cli options for linter/kondo."
   {:spec
@@ -31,11 +33,13 @@
     :no-fail      		{:coerce :boolean :desc "Set to true when the linter should not return a non zero exit code at any errors."}
     :help         		{:coerce :boolean :desc "Show help."}}})
 
+
 (defn- print-help
   "Print help for the lint task."
   []
   (println "Run kondo to lint the codebase.\n")
   (println (cli/format-opts cli-options)))
+
 
 (defn lint
   "Run kondo to lint the codebase."

--- a/src/clci/tools/mkdocs.clj
+++ b/src/clci/tools/mkdocs.clj
@@ -1,7 +1,8 @@
 (ns clci.tools.mkdocs
   (:require
-   [babashka.cli :as cli]
-   [clci.proc-wrapper :as pw]))
+    [babashka.cli :as cli]
+    [clci.proc-wrapper :as pw]))
+
 
 (def cli-options
   ""
@@ -10,25 +11,31 @@
     :serve  {:coerce :boolean :desc "Serve the documentation on localhost including hot reloading."}
     :help   {:coerce :boolean :desc "Show help."}}})
 
+
 (defn- print-help
   "Print help for the docs task."
   []
   (println "Run mkdocs to build the documentation.\n")
   (println (cli/format-opts cli-options)))
 
+
 (defmulti docs-impl (fn [& args] (first args)))
+
 
 ;; Build the documentation
 (defmethod docs-impl :build [& _]
   (pw/wrap-process ["mkdocs build"]))
 
+
 ;; Run a server on localhost to serve the documentation
 (defmethod docs-impl :serve [& _]
   (pw/wrap-process ["mkdocs serve"]))
 
+
 ;; Default handler to catch invalid arguments, print help
 (defmethod docs-impl :default [& _]
   (print-help))
+
 
 (defn docs!
   "Run mkdocs."

--- a/src/clci/util.clj
+++ b/src/clci/util.clj
@@ -1,7 +1,9 @@
 (ns clci.util
   "Utilities required by several modules of the project."
   (:require
-   [clojure.string :as str]))
+    [clojure.edn :as edn]
+    [clojure.string :as str]))
+
 
 (defn join-paths
   "Takes an arboitrary number of (partital) paths and joins them together.
@@ -14,10 +16,19 @@
 	"
   [& parts]
   (as-> (map #(str/split % #"/") parts) $
-    (apply concat $)
-    (str/join "/" $)))
+        (apply concat $)
+        (str/join "/" $)))
+
 
 (defn get-paths
   "TODO: combine with utils from monorepo!"
   []
   ["src"])
+
+
+(defn read-repo
+  "Read the repo configuration."
+  []
+  (-> (slurp "repo.edn")
+      ;; TODO: Add checks that the mandatory fields are here!
+      (edn/read-string)))

--- a/test/clci/conventional_commit_test.clj
+++ b/test/clci/conventional_commit_test.clj
@@ -1,14 +1,16 @@
 (ns clci.conventional-commit-test
   "This module provides tests for the conventional commit parser."
   (:require
-   [clci.conventional-commit :refer [valid-commit-msg? parser parse-only-valid get-type get-scope]]
-   [clojure.test :refer [deftest testing is]]
-   [instaparse.core :as insta]))
+    [clci.conventional-commit :refer [valid-commit-msg? parser parse-only-valid get-type get-scope]]
+    [clojure.test :refer [deftest testing is]]
+    [instaparse.core :as insta]))
+
 
 (defn parseable?
   "Helper function to test if the given `msg` (string) can be parsed with the given `parser`."
   [parser msg]
   (not (insta/failure? (insta/parse parser msg))))
+
 
 (def valid-messages
   "Defines a collection of pairs of valid messages and their corresponding AST. Used to run tests."
@@ -48,9 +50,9 @@
         [:TEXT "This commit implements a fix of input validation. It is very good."]]])]
    ;; 7
    [(str
-     "fix: resolves input error of #RR-22\n\n"
-     "This commit implements a fix of input validation. It is very good.\n\n"
-     "And another paragraph.\n")
+      "fix: resolves input error of #RR-22\n\n"
+      "This commit implements a fix of input validation. It is very good.\n\n"
+      "And another paragraph.\n")
     '([:TYPE "fix"]
       [:SUBJECT
        [:TEXT "resolves input error of "]
@@ -62,9 +64,9 @@
         [:TEXT "And another paragraph."]]])]
    ;; 8
    [(str
-     "fix: resolves input error of #RR-22\n\n"
-     "This commit implements a fix of input validation. It is very good.\n\n"
-     "And another paragraph with an issue #RR-123.\n")
+      "fix: resolves input error of #RR-22\n\n"
+      "This commit implements a fix of input validation. It is very good.\n\n"
+      "And another paragraph with an issue #RR-123.\n")
     '([:TYPE "fix"]
       [:SUBJECT
        [:TEXT "resolves input error of "]
@@ -78,10 +80,10 @@
         [:TEXT "."]]])]
    ;; 9
    [(str
-     "fix: resolves input error of #RR-22\n\n"
-     "This commit implements a fix of input validation. It is very good.\n\n"
-     "One more paragraph.\n\n"
-     "And another paragraph with an issue #RR-123.\n")
+      "fix: resolves input error of #RR-22\n\n"
+      "This commit implements a fix of input validation. It is very good.\n\n"
+      "One more paragraph.\n\n"
+      "And another paragraph with an issue #RR-123.\n")
     '([:TYPE "fix"]
       [:SUBJECT
        [:TEXT "resolves input error of "]
@@ -97,9 +99,9 @@
         [:TEXT "."]]])]
    ;; 10
    [(str
-     "feat: switch to new API #RR-33\n\n"
-     "With this commit we are switching to the new API. Please update your access token!\n\n"
-     "BREAKING CHANGE: will not work with library xzy before 0.2.4\n")
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "BREAKING CHANGE: will not work with library xzy before 0.2.4\n")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
@@ -113,10 +115,10 @@
         [:FOOTER-VALUE [:TEXT "will not work with library xzy before 0.2.4"]]]])]
    ;; 11
    [(str
-     "feat: switch to new API #RR-33\n\n"
-     "With this commit we are switching to the new API. Please update your access token!\n\n"
-     "BREAKING CHANGE: will not work with library xzy before 0.2.4\n"
-     "note: Thanks for all the fish.\n")
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "BREAKING CHANGE: will not work with library xzy before 0.2.4\n"
+      "note: Thanks for all the fish.\n")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
@@ -133,9 +135,9 @@
         [:FOOTER-VALUE [:TEXT "Thanks for all the fish."]]]])]
    ;; 12
    [(str
-     "feat: switch to new API #RR-33\n\n"
-     "With this commit we are switching to the new API. Please update your access token!\n\n"
-     "note: Thanks for all the fish.\n")
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "note: Thanks for all the fish.\n")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
@@ -149,10 +151,10 @@
         [:FOOTER-VALUE [:TEXT "Thanks for all the fish."]]]])]
    ;; 13
    [(str
-     "feat: switch to new API #RR-33\n\n"
-     "With this commit we are switching to the new API. Please update your access token!\n\n"
-     "note: Thanks for all the fish.\n"
-     "more: Don't forget to look at #RR-45!\n")
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "note: Thanks for all the fish.\n"
+      "more: Don't forget to look at #RR-45!\n")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
@@ -172,11 +174,11 @@
          [:TEXT "!"]]]])]
    ;; 14
    [(str
-     "feat: switch to new API #RR-33\n\n"
-     "With this commit we are switching to the new API. Please update your access token!\n\n"
-     "note: Thanks for all the fish.\n"
-     "see-docs: See [the docs](https://www.example.com/foo?id=22&page=3)\n"
-     "more: Don't forget to look at #RR-45!\n")
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "note: Thanks for all the fish.\n"
+      "see-docs: See [the docs](https://www.example.com/foo?id=22&page=3)\n"
+      "more: Don't forget to look at #RR-45!\n")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
@@ -200,9 +202,9 @@
    ;;
    ;; 15
    [(str
-     "feat: switch to new API #RR-33\n\n"
-     "With this commit we are switching to the new API. Please update your access token!\n\n"
-     "# Please enter a commit message")
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "# Please enter a commit message")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
@@ -214,10 +216,10 @@
        [:COMMENT " Please enter a commit message"]])]
    ;; 16
    [(str
-     "feat: switch to new API #RR-33\n\n"
-     "With this commit we are switching to the new API. Please update your access token!\n\n"
-     "BREAKING CHANGE: will not work with library xzy before 0.2.4\n\n"
-     "# Please enter a commit message")
+      "feat: switch to new API #RR-33\n\n"
+      "With this commit we are switching to the new API. Please update your access token!\n\n"
+      "BREAKING CHANGE: will not work with library xzy before 0.2.4\n\n"
+      "# Please enter a commit message")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
@@ -233,15 +235,15 @@
        [:COMMENT " Please enter a commit message"]])]
    ;; 17
    [(str
-     "feat: switch to new API #RR-33\n\n"
-     "BREAKING CHANGE: With this commit we are switching to the new API. Please update your access token!\n\n"
-     "# Please enter the commit message for your changes. Lines starting\n"
-     "#  with '#' will be ignored, and an empty message aborts the commit.\n"
-     "#\n"
-     "# Date:      Thu Dec 8 17:01:23 2022 +0100\n"
-     "# On branch feat/rr-2\n"
-     "# Changes to be committed:\n"
-     "#       renamed:    ci-bb/src/clj/ci_bb/pod.clj -> ci-bb/src/clj/ci_bb/main.clj")
+      "feat: switch to new API #RR-33\n\n"
+      "BREAKING CHANGE: With this commit we are switching to the new API. Please update your access token!\n\n"
+      "# Please enter the commit message for your changes. Lines starting\n"
+      "#  with '#' will be ignored, and an empty message aborts the commit.\n"
+      "#\n"
+      "# Date:      Thu Dec 8 17:01:23 2022 +0100\n"
+      "# On branch feat/rr-2\n"
+      "# Changes to be committed:\n"
+      "#       renamed:    ci-bb/src/clj/ci_bb/pod.clj -> ci-bb/src/clj/ci_bb/main.clj")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "switch to new API "]
@@ -271,28 +273,28 @@
        [:ISSUE-REF [:ISSUE-ID "123"]]])]
    ;; 20
    [(str
-     "feat: implements pod optimizations of #7\n"
-     "\n"
-     "This commit updates how the pod is build. This includes\n"
-     "- writing a correct Pom file according to babashkas pod spec\n"
-     "- including different platforms and architectures for pods\n"
-     "- versioned file names for pods\n"
-     "- cleaning everything up\n"
-     "# Please enter the commit message for your changes. Lines starting\n"
-     "# with '#' will be ignored, and an empty message aborts the commit.\n"
-     "#\n"
-     "# On branch feat/clci-7\n"
-     "# Changes to be committed:\n"
-     "# new file:   .babashka/clci-0.1.2.main.metadata.cache\n"
-     "# modified:   bb.edn\n"
-     "# modified:   bb/build.clj\n"
-     "# modified:   build.clj\n"
-     "# modified:   deps.edn\n"
-     "# deleted:    manifest.edn\n"
-     "# new file:   resources/clockworksio/clci/pod-manifest.edn\n"
-     "# modified:   src/clj/user.clj\n"
-     "# modified:   test/clci/conventional_commit_test.clj\n"
-     "#\n")
+      "feat: implements pod optimizations of #7\n"
+      "\n"
+      "This commit updates how the pod is build. This includes\n"
+      "- writing a correct Pom file according to babashkas pod spec\n"
+      "- including different platforms and architectures for pods\n"
+      "- versioned file names for pods\n"
+      "- cleaning everything up\n"
+      "# Please enter the commit message for your changes. Lines starting\n"
+      "# with '#' will be ignored, and an empty message aborts the commit.\n"
+      "#\n"
+      "# On branch feat/clci-7\n"
+      "# Changes to be committed:\n"
+      "# new file:   .babashka/clci-0.1.2.main.metadata.cache\n"
+      "# modified:   bb.edn\n"
+      "# modified:   bb/build.clj\n"
+      "# modified:   build.clj\n"
+      "# modified:   deps.edn\n"
+      "# deleted:    manifest.edn\n"
+      "# new file:   resources/clockworksio/clci/pod-manifest.edn\n"
+      "# modified:   src/clj/user.clj\n"
+      "# modified:   test/clci/conventional_commit_test.clj\n"
+      "#\n")
     '([:TYPE "feat"]
       [:SUBJECT
        [:TEXT "implements pod optimizations of "]
@@ -325,6 +327,7 @@
        [:COMMENT " modified:   test/clci/conventional_commit_test.clj"]
        [:COMMENT ""]])]])
 
+
 (def invalid-messages
   "Defines a collection of invalid messages to test the parser."
   [;; 0
@@ -344,24 +347,29 @@
    ;; 7
    "feat: adding a new awesome feature\nBREAKING reason\ntoken value"])
 
+
 (deftest validate-messages
   (testing "Testing to validate correct commit messages."
     (doseq [[message _] valid-messages]
       (is (parseable? parser message)))))
 
+
 (deftest validate-messages-api
   (testing "Testing Method to validate commit messages trough pod's."
     (is (valid-commit-msg? (get-in valid-messages [0 0])))))
+
 
 (deftest parse-messages
   (testing "Testing to parse valid commit messages."
     (doseq [[message expected] valid-messages]
       (is (= expected (insta/parse parser message))))))
 
+
 (deftest parse-invalid-messages
   (testing "Testing to parse invalid commit messages. Expect to fail!"
     (doseq [message invalid-messages]
       (is (insta/failure? (insta/parse parser message))))))
+
 
 (deftest test-parse-only-valid
   (testing "Testing the `parse-only-valid` shortcut function."
@@ -392,12 +400,14 @@
       (is (= (get-in valid-messages [16 1]) (nth res-col 7)))
       (is (= (get-in valid-messages [19 1]) (nth res-col 8))))))
 
+
 (deftest test-get-type
   (testing "Testing the `get-type` function to get the type of a CC message."
     (is (= "feat" (get-type (get-in valid-messages [0 1]))))
     (is (= "chore" (get-type (get-in valid-messages [1 1]))))
     (is (= "fix" (get-type (get-in valid-messages [2 1]))))
     (is (= "build" (get-type (get-in valid-messages [3 1]))))))
+
 
 (deftest test-get-scope
   (testing "Testing the `get-scope` function to get the type of a CC message."

--- a/test/clci/git_test.clj
+++ b/test/clci/git_test.clj
@@ -1,5 +1,5 @@
 (ns clci.git-test
   "This module provides tests for the `git` module."
   (:require
-   [clci.git :as g]
-   [clojure.test :refer [deftest testing is]]))
+    [clci.git :as g]
+    [clojure.test :refer [deftest testing is]]))

--- a/test/clci/semver_test.clj
+++ b/test/clci/semver_test.clj
@@ -1,8 +1,9 @@
 (ns clci.semver-test
   "This module provides tests for the semantic versioning module."
   (:require
-   [clci.semver :refer [valid-version-tag? major minor patch pre-release]]
-   [clojure.test :refer [deftest testing is]]))
+    [clci.semver :refer [valid-version-tag? major minor patch pre-release]]
+    [clojure.test :refer [deftest testing is]]))
+
 
 (deftest valid-tags
   (testing "Testing to validate tags that correctly follow the semver specs."
@@ -13,12 +14,14 @@
     (is (valid-version-tag? "3.0.1-SNAPSHOT"))
     (is (valid-version-tag? "1.21.12-next"))))
 
+
 (deftest in-valid-tags
   (testing "Testing to validate tags that NOT correctly follow the semver specs."
     (is (not (valid-version-tag? "0..1")))
     (is (not (valid-version-tag? "v0.2.1")))
     (is (not (valid-version-tag? "20221203")))
     (is (not (valid-version-tag? "bumblebee")))))
+
 
 (deftest get-version-parts
   (testing "Testing utilities to get the version parts."


### PR DESCRIPTION
# Description
This change implements a subset of the Github API required by clci to create releases using semantic versioning and the git log.

Also moves back to `cljstyle` in favor of `cljfmt` because the Action in the pipeline does not support it.

Resolves #45 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The Acceptance Criteria of the related issue are satisfied
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules