### PR TITLE
fix: invalid sha from gh endpoint

### DIFF
--- a/repo.edn
+++ b/repo.edn
@@ -1,4 +1,4 @@
-{:version "0.0.0.",
+{:version "0.12.2.",
  :scm
  {:name "git",
   :url "git@github.com:ClockworksIO/clci.git",

--- a/src/clci/gh/core.clj
+++ b/src/clci/gh/core.clj
@@ -115,8 +115,13 @@
   "Get a tag object.
   Takes the `owner` and the `repo` name and the `tag`."
   [owner repo tag]
-  (-> (http/get (path endpoint "repos" owner repo "git" "ref" "tags" tag)
-                (with-headers {}))
-      :body
-      (cheshire/parse-string true)))
+  (let [url   (-> (http/get (path endpoint "repos" owner repo "git" "ref" "tags" tag)
+                            (with-headers {}))
+                  :body
+                  (cheshire/parse-string true)
+                  :object
+                  :url)]
+    (-> (http/get url (with-headers {}))
+        :body
+        (cheshire/parse-string true))))
 


### PR DESCRIPTION
# Description

Fixes a problem with getting the commit SHA of a specific tag.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules