### PR TITLE
fix: dont set release update flag as default true

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -61,6 +61,10 @@ jobs:
         run: bb clci release --update-version
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      # Update Changelog for the release
+      # - name: Update Changelog
+      #   id: update-changelog
+      #   run: bb clci run job update-changelog --release ${{ steps. }}
       # Add and commit the new version
       - name: Commit Release Changes
         run: |

--- a/src/clci/tools/core.clj
+++ b/src/clci/tools/core.clj
@@ -229,7 +229,7 @@ Options:
 (defn release!
   "Create a new release."
   [_]
-  (let [spec   {:update-version   {:coerce :boolean :default true :desc "Set if you would like to update the version of all products."}
+  (let [spec   {:update-version   {:coerce :boolean :default false :desc "Set if you would like to update the version of all products."}
                 :create-releases  {:coerce :boolean :Default false :desc "Set to create releases for all products."}
                 :draft            {:coerce :boolean :desc "Set if you would like to mark the new release as draft."}
                 :pre-release      {:coerce :boolean :desc "Set if you would like to mark the new release as pre-release."}


### PR DESCRIPTION
# Description

Fixes the broken pipeline: A new release was not created correctly because the release implementation used a default true coercion for the `--update-version` flag and thus never created a new release but only incremented the version of the product.

Resolves #110 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing with changes and manual invocation of the release function.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules