### PR TITLE
feat: add optional trunk branch arg #143

### DIFF
--- a/repo.edn
+++ b/repo.edn
@@ -1,6 +1,7 @@
 {:scm
  {:type :git,
   :url "git@github.com:ClockworksIO/clci.git",
+  :trunk "master"
   :provider {:name :github, :repo "clci", :owner "ClockworksIO"}},
  :products
  [{:root ".",

--- a/src/clci/repo.clj
+++ b/src/clci/repo.clj
@@ -27,6 +27,7 @@
 
 (s/def :clci.repo.scm/type valid-scm)
 (s/def :clci.repo.scm/url string?)
+(s/def :clci.repo.scm/trunk string?)
 (s/def :clci.repo.scm.provider/name valid-scm-provider)
 (s/def :clci.repo.scm.provider/repo string?)
 (s/def :clci.repo.scm.provider/owner string?)
@@ -40,7 +41,9 @@
 
 (s/def :clci.repo/scm
   (s/keys :req-un [:clci.repo.scm/type
-                   :clci.repo.scm/url]))
+                   :clci.repo.scm/url
+                   :clci.repo.scm/provider]
+          :opt-un [:clci.repo.scm/trunk]))
 
 
 (s/def :clci.repo.product/root string?)


### PR DESCRIPTION
# Description

This commit adds an extra (optional) argument to the release task to specify a branch name to use as trunk. This allows to use a branch naming scheme where the trunk is named different than _master_.

This commit also allows to set the trunk branch in the _repo.edn_ file.

Resolves #143

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

...

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The Acceptance Criteria of the related issue are satisfied
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Test coverage does not decrease with my changes
- [x] Any dependent changes have been merged and published in downstream modules